### PR TITLE
Fix #27: Re-load clantag from settings; make TextBox use string pointer instead of value

### DIFF
--- a/src/UI/strptextbox.h
+++ b/src/UI/strptextbox.h
@@ -1,12 +1,12 @@
-#ifndef __TEXTBOX_H_
-#define __TEXTBOX_H_
+#ifndef __STRPTEXTBOX_H_
+#define __STRPTEXTBOX_H_
 
 #include "component.h"
 #include "../settings.h"
 #include "../util.h"
 #include <algorithm>
 
-class TextBox : public Component
+class StrPTextBox : public Component
 {
 protected:
 	Color text_color = Color (255, 255, 255, 200);
@@ -19,15 +19,15 @@ private:
 	int s_caret_stamp;
 public:
 	
-	pstring text;
+    std::string* text;
 	std::string shadow_text = "textbox";
 	
-	TextBox (std::string shadow_text, std::string default_text, Vector2D position, Vector2D size)
+	StrPTextBox (std::string shadow_text, std::string* textref, Vector2D position, Vector2D size)
 	{
 		this->position = position;
 		this->size = size;
 		this->shadow_text = shadow_text;
-		this->text = default_text;
+		this->text = textref;
 		
 		// Get the width if the monospaced font
 		font_size = Draw::GetTextSize ("j", mono_font);
@@ -48,7 +48,7 @@ public:
 		
 		int text_max_fit = (size.x-20) / font_size.x;
 		
-		const char* sectioned_text = (text.size() > text_max_fit ? &text.c_str()[text.size()-text_max_fit] : text.c_str());
+		const char* sectioned_text = (text->size() > text_max_fit ? &text->c_str()[text->size() - text_max_fit] : text->c_str());
 		
 		int sectioned_text_size = strlen(sectioned_text);
 		
@@ -114,23 +114,23 @@ public:
 				character = Util::GetUpperValueOf(key);
 			}
 			
-			text += character;
+			text->operator+=(character);
 		}
 		
-		if (text.size() > 0 &&
+		if (text->size() > 0 &&
 			std::find(pressedKeys.begin(), pressedKeys.end(), KEY_BACKSPACE) != pressedKeys.end() &&
 			std::find(lastPressedKeys.begin(), lastPressedKeys.end(), KEY_BACKSPACE) == lastPressedKeys.end()
 			)
 		{
-			text.pop_back ();
+			text->pop_back ();
 		}
 		
-		if (text.size() > 0 &&
+		if (text->size() > 0 &&
 			std::find(pressedKeys.begin(), pressedKeys.end(), KEY_SPACE) != pressedKeys.end() &&
 			std::find(lastPressedKeys.begin(), lastPressedKeys.end(), KEY_SPACE) == lastPressedKeys.end()
 			)
 		{
-			text << " ";
+			text->operator+=(" ");
 		}
 		
 		lastPressedKeys = pressedKeys;

--- a/src/UI/textbox.h
+++ b/src/UI/textbox.h
@@ -19,15 +19,15 @@ private:
 	int s_caret_stamp;
 public:
 	
-	pstring text;
+    std::string* text;
 	std::string shadow_text = "textbox";
 	
-	TextBox (std::string shadow_text, std::string default_text, Vector2D position, Vector2D size)
+	TextBox (std::string shadow_text, std::string* textref, Vector2D position, Vector2D size)
 	{
 		this->position = position;
 		this->size = size;
 		this->shadow_text = shadow_text;
-		this->text = default_text;
+		this->text = textref;
 		
 		// Get the width if the monospaced font
 		font_size = Draw::GetTextSize ("j", mono_font);
@@ -48,7 +48,7 @@ public:
 		
 		int text_max_fit = (size.x-20) / font_size.x;
 		
-		const char* sectioned_text = (text.size() > text_max_fit ? &text.c_str()[text.size()-text_max_fit] : text.c_str());
+		const char* sectioned_text = (text->size() > text_max_fit ? &text->c_str()[text->size() - text_max_fit] : text->c_str());
 		
 		int sectioned_text_size = strlen(sectioned_text);
 		
@@ -114,23 +114,23 @@ public:
 				character = Util::GetUpperValueOf(key);
 			}
 			
-			text += character;
+			text->operator+=(character);
 		}
 		
-		if (text.size() > 0 &&
+		if (text->size() > 0 &&
 			std::find(pressedKeys.begin(), pressedKeys.end(), KEY_BACKSPACE) != pressedKeys.end() &&
 			std::find(lastPressedKeys.begin(), lastPressedKeys.end(), KEY_BACKSPACE) == lastPressedKeys.end()
 			)
 		{
-			text.pop_back ();
+			text->pop_back ();
 		}
 		
-		if (text.size() > 0 &&
+		if (text->size() > 0 &&
 			std::find(pressedKeys.begin(), pressedKeys.end(), KEY_SPACE) != pressedKeys.end() &&
 			std::find(lastPressedKeys.begin(), lastPressedKeys.end(), KEY_SPACE) == lastPressedKeys.end()
 			)
 		{
-			text << " ";
+			text->operator+=(" ");
 		}
 		
 		lastPressedKeys = pressedKeys;

--- a/src/WINDOWS/misc_window.cpp
+++ b/src/WINDOWS/misc_window.cpp
@@ -32,7 +32,7 @@ MiscWindow::MiscWindow (std::string title, Vector2D size, Vector2D position, Col
 	sl_noflash_value = new Slider ("", STACK (ts_noflash_enabled), LOC (size.x - ts_noflash_enabled->size.x - 30, 33), &Settings::Noflash::value, 0.0f, 255.0f);
 	AddComponent (sl_noflash_value);
 	
-	tb_clantag = new TextBox ("clantag", Settings::ClanTagChanger::value, BELOW (ts_noflash_enabled), LOC (270, 30));
+	tb_clantag = new TextBox ("clantag", &Settings::ClanTagChanger::value, BELOW (ts_noflash_enabled), LOC (270, 30));
 	AddComponent (tb_clantag);
 	
 	ob_clantag_set = new OutlinedButton ("set clan tag", STACK (tb_clantag), LOC (110, 30));
@@ -47,6 +47,6 @@ MiscWindow::MiscWindow (std::string title, Vector2D size, Vector2D position, Col
 
 void MiscWindow::SetClanTag ()
 {
-	std::string text = Util::ReplaceString(tb_clantag->text, "\\n", "\n");
-	Settings::ClanTagChanger::value = strdup(text.c_str());
+    // Side-effecting (referential)
+    Util::StdReplaceStr(Settings::ClanTagChanger::value, "\\n", "\n");
 }

--- a/src/WINDOWS/misc_window.cpp
+++ b/src/WINDOWS/misc_window.cpp
@@ -37,7 +37,7 @@ MiscWindow::MiscWindow (std::string title, Vector2D size, Vector2D position, Col
 	ts_clantag_enable = new ToggleSwitch ("custom clantag", BELOW (ts_noflash_enabled), LOC (155, 30), &Settings::ClanTagChanger::enable);
 	AddComponent (ts_clantag_enable);
 
-	tb_clantag = new TextBox ("clantag", &Settings::ClanTagChanger::value, STACK (ts_clantag_enable), LOC (270, 30));
+	tb_clantag = new StrPTextBox ("clantag", &Settings::ClanTagChanger::value, STACK (ts_clantag_enable), LOC (270, 30));
 	AddComponent (tb_clantag);
 	
 	

--- a/src/WINDOWS/misc_window.cpp
+++ b/src/WINDOWS/misc_window.cpp
@@ -31,22 +31,18 @@ MiscWindow::MiscWindow (std::string title, Vector2D size, Vector2D position, Col
 	
 	sl_noflash_value = new Slider ("", STACK (ts_noflash_enabled), LOC (size.x - ts_noflash_enabled->size.x - 30, 33), &Settings::Noflash::value, 0.0f, 255.0f);
 	AddComponent (sl_noflash_value);
-	
-	tb_clantag = new TextBox ("clantag", &Settings::ClanTagChanger::value, BELOW (ts_noflash_enabled), LOC (270, 30));
+
+    // clantag
+
+	ts_clantag_enable = new ToggleSwitch ("custom clantag", BELOW (ts_noflash_enabled), LOC (155, 30), &Settings::ClanTagChanger::enable);
+	AddComponent (ts_clantag_enable);
+
+	tb_clantag = new TextBox ("clantag", &Settings::ClanTagChanger::value, STACK (ts_clantag_enable), LOC (270, 30));
 	AddComponent (tb_clantag);
 	
-	ob_clantag_set = new OutlinedButton ("set clan tag", STACK (tb_clantag), LOC (110, 30));
-	AddComponent (ob_clantag_set);
-	ob_clantag_set->OnClickedEvent = MFUNC (&MiscWindow::SetClanTag, this);
 	
 	ts_clantag_animation = new ToggleSwitch ("clantag animation", BELOW (tb_clantag), 33, &Settings::ClanTagChanger::animation);
 	AddComponent (ts_clantag_animation);
 	
 	Hide ();
-}
-
-void MiscWindow::SetClanTag ()
-{
-    // Side-effecting (referential)
-    Util::StdReplaceStr(Settings::ClanTagChanger::value, "\\n", "\n");
 }

--- a/src/WINDOWS/misc_window.h
+++ b/src/WINDOWS/misc_window.h
@@ -19,8 +19,8 @@ private:
 	ToggleSwitch* ts_showspectators;
 	ToggleSwitch* ts_noflash_enabled;
 	Slider* sl_noflash_value;
+	ToggleSwitch* ts_clantag_enable;
 	TextBox* tb_clantag;
-	OutlinedButton* ob_clantag_set;
 	ToggleSwitch* ts_clantag_animation;
 public:
 	MiscWindow (std::string title, Vector2D size, Vector2D position, Color backgroundColor);

--- a/src/WINDOWS/misc_window.h
+++ b/src/WINDOWS/misc_window.h
@@ -6,6 +6,7 @@ class MiscWindow;
 #include "../UI/stdui.h"
 #include "../atgui.h"
 #include "../util.h"
+#include "../UI/strptextbox.h"
 
 class MiscWindow : public Window
 {
@@ -20,7 +21,7 @@ private:
 	ToggleSwitch* ts_noflash_enabled;
 	Slider* sl_noflash_value;
 	ToggleSwitch* ts_clantag_enable;
-	TextBox* tb_clantag;
+	StrPTextBox* tb_clantag;
 	ToggleSwitch* ts_clantag_animation;
 public:
 	MiscWindow (std::string title, Vector2D size, Vector2D position, Color backgroundColor);

--- a/src/chantagchanger.cpp
+++ b/src/chantagchanger.cpp
@@ -1,6 +1,6 @@
 #include "chantagchanger.h"
 
-char* Settings::ClanTagChanger::value = (char*) "";
+std::string Settings::ClanTagChanger::value = "";
 bool Settings::ClanTagChanger::animation = false;
 std::vector<ClanTagChanger::Animation> ClanTagChanger::animations =
 {
@@ -24,7 +24,7 @@ void ClanTagChanger::CreateMove(CUserCmd* cmd)
 	if (!engine->IsInGame())
 		return;
 
-	if (strlen(Settings::ClanTagChanger::value) == 0 && !Settings::ClanTagChanger::animation)
+	if (Settings::ClanTagChanger::value.size() == 0 && !Settings::ClanTagChanger::animation)
 		return;
 
 	long currentTime_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -40,5 +40,5 @@ void ClanTagChanger::CreateMove(CUserCmd* cmd)
 	if (Settings::ClanTagChanger::animation)
 		SendClanTag(ClanTagChanger::animation->GetCurrentFrame().text.c_str(), "");
 	else
-		SendClanTag(Settings::ClanTagChanger::value, "");
+		SendClanTag(Settings::ClanTagChanger::value.c_str(), "");
 }

--- a/src/chantagchanger.cpp
+++ b/src/chantagchanger.cpp
@@ -1,7 +1,10 @@
 #include "chantagchanger.h"
+#include "util.h"
 
 std::string Settings::ClanTagChanger::value = "";
 bool Settings::ClanTagChanger::animation = false;
+bool Settings::ClanTagChanger::enable = false; // TODO find a way to go back to the "official" clan tag for the player?
+
 std::vector<ClanTagChanger::Animation> ClanTagChanger::animations =
 {
 	Animation ("NOVAC",
@@ -21,7 +24,8 @@ ClanTagChanger::Animation* ClanTagChanger::animation = &ClanTagChanger::animatio
 
 void ClanTagChanger::CreateMove(CUserCmd* cmd)
 {
-	if (!engine->IsInGame())
+
+	if (!engine->IsInGame() || !Settings::ClanTagChanger::enable)
 		return;
 
 	if (Settings::ClanTagChanger::value.size() == 0 && !Settings::ClanTagChanger::animation)
@@ -39,6 +43,10 @@ void ClanTagChanger::CreateMove(CUserCmd* cmd)
 
 	if (Settings::ClanTagChanger::animation)
 		SendClanTag(ClanTagChanger::animation->GetCurrentFrame().text.c_str(), "");
-	else
-		SendClanTag(Settings::ClanTagChanger::value.c_str(), "");
+	else 
+    {
+        std::string ctWithEscapesProcessed = std::string(Settings::ClanTagChanger::value); 
+        Util::StdReplaceStr(ctWithEscapesProcessed, "\\n", "\n"); // compute time impact? also, referential so i assume RAII builtin cleans it up...
+		SendClanTag(ctWithEscapesProcessed.c_str(), "");
+    }
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -186,6 +186,7 @@ void Settings::LoadDefaultsOrSave(const char* filename)
 	settings["ShowSpectators"]["enabled"] = Settings::ShowSpectators::enabled;
 
 	settings["ClanTagChanger"]["value"] = Settings::ClanTagChanger::value;
+    settings["ClanTagChanger"]["enable"] = Settings::ClanTagChanger::enable;
 
 	std::ofstream(GetSettingsPath(filename)) << styledWriter.write(settings);
 }
@@ -318,7 +319,9 @@ void Settings::LoadSettings(const char* filename)
 		GetBool(settings["ShowRanks"]["enabled"], Settings::ShowRanks::enabled);
 
 		GetBool(settings["ShowSpectators"]["enabled"], Settings::ShowSpectators::enabled);
+
         GetString(settings["ClanTagChanger"]["value"], &Settings::ClanTagChanger::value);
+        GetBool(settings["ClanTagChanger"]["enable"], Settings::ClanTagChanger::enable);
 	}
 	else
 	{

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,4 +1,5 @@
 #include "settings.h"
+#include "interfaces.h"
 
 char* GetSettingsPath(const char* filename)
 {
@@ -27,12 +28,12 @@ void GetCString(Json::Value &config, char* &setting)
 	setting = strdup(config.asCString());
 }
 
-void GetString(Json::Value &config, std::string &setting)
+void GetString(Json::Value &config, std::string* /* references are for pussies */ setting)
 {
 	if (config.isNull())
 		return;
 
-	setting = config.asString();
+	*setting = config.asString();
 }
 
 template <typename Type>
@@ -317,6 +318,7 @@ void Settings::LoadSettings(const char* filename)
 		GetBool(settings["ShowRanks"]["enabled"], Settings::ShowRanks::enabled);
 
 		GetBool(settings["ShowSpectators"]["enabled"], Settings::ShowSpectators::enabled);
+        GetString(settings["ClanTagChanger"]["value"], &Settings::ClanTagChanger::value);
 	}
 	else
 	{

--- a/src/settings.h
+++ b/src/settings.h
@@ -311,7 +311,7 @@ namespace Settings
 
 	namespace ClanTagChanger
 	{
-		extern char* value;
+		extern std::string value;
 		extern bool animation;
 	}
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -313,6 +313,7 @@ namespace Settings
 	{
 		extern std::string value;
 		extern bool animation;
+        extern bool enable;
 	}
 
 	void LoadDefaultsOrSave(const char* filename);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -107,3 +107,22 @@ char Util::GetUpperValueOf(ButtonCode_t key)
 			return buttonChar;
 	}
 }
+
+void Util::StdReplaceStr(std::string& replaceIn, const std::string& replace, const std::string& replaceWith)
+{
+    size_t const span = replace.size();
+    size_t const step = replaceWith.size(); 
+    size_t index = 0;
+    while (true)
+    {
+        index = replaceIn.find(replace, index);
+        
+        if (index == std::string::npos)
+        {
+            break;
+        }
+
+        replaceIn.replace(index, span, replaceWith);
+        index += step;
+    }
+}

--- a/src/util.h
+++ b/src/util.h
@@ -9,6 +9,7 @@ namespace Util {
 	std::string ReplaceString(std::string subject, const std::string& search, const std::string& replace);
 	char GetButtonString(ButtonCode_t key);
 	char GetUpperValueOf(ButtonCode_t key);
+    void StdReplaceStr(std::string&, const std::string&, const std::string&);
 }
 
 #endif


### PR DESCRIPTION
Also: 
* adds a toggle for clantag changer (half working - doesn't revert to actual clan tag)
*  move `\n => <newline>` replacement to send-time so that it's not saved/does not modify the actual settings value
* change type of `Settings::ClanTagChanger::value` to `std::string` from char array.
* Correct `GetString` logic to actually update string contents
* Add a search/replace algo to `Util` that operates on `std::string`.