### PR TITLE
Add local vimrc

### DIFF
--- a/_local_vimrc.vim
+++ b/_local_vimrc.vim
@@ -1,0 +1,1 @@
+set autoindent noexpandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
This should make sure anyone with `local_vimrc` installed (myself included) uses tabs by default.