### PR TITLE
Add base classes and signatures for engine prediction.

### DIFF
--- a/src/AimTux.cpp
+++ b/src/AimTux.cpp
@@ -21,6 +21,7 @@ int __attribute__((constructor)) aimtux_init()
 	Hooker::HookRankReveal();
 	Hooker::HookSendClanTag();
 	Hooker::HookSendPacket();
+	Hooker::HookPrediction();
 
 	Chams::CreateMaterials();
 

--- a/src/SDK/IGameMovement.h
+++ b/src/SDK/IGameMovement.h
@@ -1,0 +1,66 @@
+#pragma once
+
+class CMoveData
+{
+public:
+	bool m_bFirstRunOfFunctions;
+	bool m_bGameCodeMovedPlayer;
+	bool m_bNoAirControl;
+	unsigned long m_nPlayerHandle;
+	int m_nImpulseCommand;
+	QAngle m_vecViewAngles;
+	QAngle m_vecAbsViewAngles;
+	int m_nButtons;
+	int m_nOldButtons;
+	float m_flForwardMove;
+	float m_flSideMove;
+	float m_flUpMove;
+	float m_flMaxSpeed;
+	float m_flClientMaxSpeed;
+	Vector m_vecVelocity;
+	Vector m_vecOldVelocity;
+	float somefloat;
+	QAngle m_vecAngles;
+	QAngle m_vecOldAngles;
+	float m_outStepHeight;
+	Vector m_outWishVel;
+	Vector m_outJumpVel;
+	Vector m_vecConstraintCenter;
+	float m_flConstraintRadius;
+	float m_flConstraintWidth;
+	float m_flConstraintSpeedFactor;
+	bool m_bConstraintPastRadius;
+	Vector m_vecAbsOrigin;
+};
+
+class IGameMovement
+{
+public:
+	void ProcessMovement(IClientEntity* player, CMoveData* move)
+	{
+		typedef void (* oProcessMovement)(void*, IClientEntity*, CMoveData*);
+		getvfunc<oProcessMovement>(this, 2)(this, player, move);
+	}
+
+	void StartTrackPredictionErrors(IClientEntity* player)
+	{
+		typedef void (* oStartTrackPredictionErrors)(void*, IClientEntity*);
+		getvfunc<oStartTrackPredictionErrors>(this, 4)(this, player);
+	}
+
+	void FinishTrackPredictionErrors(IClientEntity* player)
+	{
+		typedef void (* oFinishTrackPredictionErrors)(void*, IClientEntity*);
+		getvfunc<oFinishTrackPredictionErrors>(this, 5)(this, player);
+	}
+};
+
+class IMoveHelper
+{
+public:
+	void SetHost(IClientEntity* host)
+	{
+		typedef void (* oSetHost)(void*, IClientEntity*);
+		return getvfunc<oSetHost>(this, 2)(this, host);
+	}
+};

--- a/src/SDK/IPrediction.h
+++ b/src/SDK/IPrediction.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class IPrediction
+{
+public:
+	void SetupMove(IClientEntity* player, CUserCmd* cmd, IMoveHelper* helper, CMoveData* move) 
+	{
+		typedef void (* oSetupMove)(void*, IClientEntity*, CUserCmd*, IMoveHelper*, CMoveData*);
+		getvfunc<oSetupMove>(this, 21)(this, player, cmd, helper, move);
+	}
+
+	void FinishMove(IClientEntity* player, CUserCmd* cmd, CMoveData* move)
+	{
+		typedef void (* oFinishMove)(void*, IClientEntity*, CUserCmd*, CMoveData*);
+		getvfunc<oFinishMove>(this, 22)(this, player, cmd, move);
+	}
+};

--- a/src/SDK/SDK.h
+++ b/src/SDK/SDK.h
@@ -29,3 +29,5 @@
 #include "CGlowObjectManager.h"
 #include "IPhysicsSurfaceProps.h"
 #include "CViewRender.h"
+#include "IGameMovement.h"
+#include "IPrediction.h"

--- a/src/hooker.h
+++ b/src/hooker.h
@@ -18,6 +18,12 @@
 #define BSENDPACKET_SIGNATURE "\x41\xBD\x01\x00\x00\x00\xE9\x2A\xFE"
 #define BSENDPACKET_MASK "xxx???xxx"
 
+#define PREDICTION_RANDOM_SEED_SIGNATURE "\x48\x8B\x05\x00\x00\x00\x00\xF3\x0F\x11\x45\xDC\xF3"
+#define PREDICTION_RANDOM_SEED_MASK "xxx????xxxxxx"
+
+#define CLIENT_MOVEHELPER_SIGNATURE "\x00\x48\x89\x3D\x00\x00\x00\x00\xC3"
+#define CLIENT_MOVEHELPER_MASK "xxxx????x"
+
 #include <unordered_map>
 #include <sys/mman.h>
 #include <link.h>
@@ -37,5 +43,6 @@ namespace Hooker
 	void HookSendClanTag();
 	void HookViewRender();
 	void HookSendPacket();
+	void HookPrediction();
 	void UnhookSendPacket();
 }

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -21,6 +21,9 @@ extern CGlobalVars* globalvars;
 extern CEffects* effects;
 extern IGameEventManager2* gameevents;
 extern IPhysicsSurfaceProps* physics;
+extern IPrediction* prediction;
+extern IGameMovement* gamemovement;
+extern IMoveHelper* movehelper;
 
 extern VMT* panel_vmt;
 extern VMT* client_vmt;
@@ -30,4 +33,5 @@ extern VMT* gameEvents_vmt;
 extern VMT* viewRender_vmt;
 extern VMT* inputInternal_vmt;
 
+extern uint32_t* nPredictionRandomSeed;
 extern bool* bSendPacket;


### PR DESCRIPTION
Played around with this in another project and it works well. I tried adding it in CreateMove here but it seemed to interfere with some other features so this covers everything but the actual implementation.

I've uploaded example usage for CreateMove [here](https://gist.github.com/aixxe/65580e54d3d759130a7882c6ee19eef4) based on the [engine prediction](https://www.unknowncheats.me/forum/counterstrike-global-offensive/189474-engine-prediction.html) code from UnKnoWnCheaTs. It's easiest to test this with `weapon_accuracy_nospread` set to 1 and recoil control in AimTux set to 2.