### PR TITLE
Add feature to automatically accept competitive matchmaking games.

### DIFF
--- a/src/AimTux.cpp
+++ b/src/AimTux.cpp
@@ -21,6 +21,7 @@ int __attribute__((constructor)) aimtux_init()
 	Hooker::HookRankReveal();
 	Hooker::HookSendClanTag();
 	Hooker::HookSendPacket();
+	Hooker::HookIsReadyCallback();
 	Hooker::HookPrediction();
 
 	Chams::CreateMaterials();
@@ -48,6 +49,9 @@ int __attribute__((constructor)) aimtux_init()
 
 	inputInternal_vmt->HookVM((void*) Hooks::SetKeyCodeState, 92);
 	inputInternal_vmt->ApplyVMT();
+	
+	surface_vmt->HookVM((void*) Hooks::PlaySound, 82);
+	surface_vmt->ApplyVMT();
 
 	surface_vmt->HookVM((void*) Hooks::OnScreenSizeChanged, 116);
 	surface_vmt->ApplyVMT();

--- a/src/Hooks/PlaySound.cpp
+++ b/src/Hooks/PlaySound.cpp
@@ -1,0 +1,8 @@
+#include "hooks.h"
+
+void Hooks::PlaySound(void* thisptr, const char* filename)
+{
+	AutoAccept::PlaySound(filename);
+
+	surface_vmt->GetOriginalMethod<PlaySoundFn>(82)(thisptr, filename);
+}

--- a/src/Hooks/hooks.h
+++ b/src/Hooks/hooks.h
@@ -14,6 +14,7 @@ typedef int (*IN_KeyEventFn) (void*, int, int, const char*);
 typedef void (*RenderViewFn) (void*, CViewSetup&, CViewSetup&, unsigned int, int);
 typedef void (*SetKeyCodeStateFn) (void*, ButtonCode_t, bool);
 typedef void (*OnScreenSizeChangedFn) (void*, int, int);
+typedef void (*PlaySoundFn) (void*, const char*);
 
 namespace Hooks
 {
@@ -26,6 +27,7 @@ namespace Hooks
 	void RenderView(void* thisptr, CViewSetup& setup, CViewSetup& hudViewSetup, unsigned int nClearFlags, int whatToDraw);
 	void SetKeyCodeState(void* thisptr, ButtonCode_t code, bool bPressed);
 	void OnScreenSizeChanged(void* thisptr, int oldwidth, int oldheight);
+	void PlaySound(void* thisptr, const char* filename);
 }
 
 namespace CreateMove

--- a/src/PANELS/misc_panel.cpp
+++ b/src/PANELS/misc_panel.cpp
@@ -30,8 +30,9 @@ MiscPanel::MiscPanel (Vector2D position, Vector2D size)
 	sl_fov_viewmodel_value = new Slider ("", STACK (ts_fov_viewmodel), LOC ((size.x / 2) - ts_fov_viewmodel->size.x - 30, 30), &Settings::FOVChanger::viewmodel_value, 0.0f, 360.0f);
 	ts_fakelag = new ToggleSwitchTip ("Fake Lag", BELOW (ts_fov_viewmodel), LOC((size.x - 20) / 6.75, 30), &Settings::FakeLag::enabled, "Chokes network packets. Don't use with fake angles");
 	sl_fakelag = new Slider_INT ("", STACK (ts_fakelag), LOC ((size.x / 2) - ts_fakelag->size.x - 30, 33), &Settings::FakeLag::value, 0, 16);
-	ts_radar = new ToggleSwitchTip ("Radar", BELOW (ts_fakelag), LOC((size.x - 20) / 6.75, 30), &Settings::Radar::enabled, "Show all enemies including people who are visible to you/team");
-	ts_showranks = new ToggleSwitchTip ("Show Ranks", BELOW (ts_radar), LOC((size.x - 20) / 6.75, 30), &Settings::ShowRanks::enabled, "Shows peoples ranks in a valve server");
+	ts_radar = new ToggleSwitchTip("Radar", BELOW(ts_fakelag), LOC((size.x - 20) / 6.75, 30), &Settings::Radar::enabled, "Show all enemies including people who are visible to you/team");
+	ts_autoaccept = new ToggleSwitchTip ("Auto Accept", BELOW (ts_radar), LOC((size.x - 20) / 6.75, 30), &Settings::AutoAccept::enabled, "Automatically accept games when in the matchmaking queue.");
+	ts_showranks = new ToggleSwitchTip ("Show Ranks", BELOW (ts_autoaccept), LOC((size.x - 20) / 6.75, 30), &Settings::ShowRanks::enabled, "Shows peoples ranks in a valve server");
 	ts_showspectators = new ToggleSwitchTip ("Show Spectators", STACK (ts_showranks), LOC((size.x - 20) / 6.75, 30), &Settings::ShowSpectators::enabled, "Shows who is spectating you");
 	ts_clantag = new ToggleSwitchTip ("Custom Clantag", BELOW (ts_showranks), LOC((size.x - 20) / 6.75, 30), &Settings::ClanTagChanger::enabled, "Set a custom clantag ");
 	tb_clantag = new TextBox ("Clantag", &Settings::ClanTagChanger::value, STACK (ts_clantag), LOC((size.x - 20) / 6.75, 30));
@@ -62,6 +63,7 @@ MiscPanel::MiscPanel (Vector2D position, Vector2D size)
 	AddComponent (ts_showspectators);
 	AddComponent (ts_showranks);
 	AddComponent (ts_radar);
+	AddComponent (ts_autoaccept);
 	AddComponent (sl_fakelag);
 	AddComponent (ts_fakelag);
 	AddComponent (sl_fov_viewmodel_value);

--- a/src/PANELS/misc_panel.h
+++ b/src/PANELS/misc_panel.h
@@ -32,6 +32,7 @@ private:
 	ToggleSwitch* ts_fov_viewmodel;
 	Slider* sl_fov_viewmodel_value;
 	ToggleSwitch* ts_radar;
+	ToggleSwitch* ts_autoaccept;
 	ToggleSwitch* ts_fakelag;
 	Slider_INT* sl_fakelag;
 	ToggleSwitch* ts_showranks;

--- a/src/SDK/definitions.h
+++ b/src/SDK/definitions.h
@@ -18,6 +18,7 @@ typedef void* (*CreateInterfaceFn) (const char*, int*);
 typedef CGlowObjectManager* (*GlowObjectManagerFn) (void);
 typedef bool (*MsgFunc_ServerRankRevealAllFn) (float*);
 typedef void (*SendClanTagFn) (const char*, const char*);
+typedef void (*IsReadyCallbackFn) (void*);
 
 struct WeaponInfo_t {
 	float m_flWeaponArmorRatio;

--- a/src/autoaccept.cpp
+++ b/src/autoaccept.cpp
@@ -1,0 +1,22 @@
+#include "autoaccept.h"
+
+bool Settings::AutoAccept::enabled = true;
+
+struct CServerConfirmedReservationCheckCallback {
+	char pad[0x2200];
+};
+
+void AutoAccept::PlaySound(const char* filename)
+{
+	if (!Settings::AutoAccept::enabled)
+		return;
+
+	if (strcmp(filename, "weapons/hegrenade/beep.wav") != 0)
+		return;
+
+	if (engine->IsInGame())
+		return;
+
+	CServerConfirmedReservationCheckCallback empty_callback;
+	IsReadyCallback(&empty_callback);
+}

--- a/src/autoaccept.h
+++ b/src/autoaccept.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "SDK/SDK.h"
+#include "interfaces.h"
+#include "settings.h"
+
+namespace AutoAccept
+{
+	void PlaySound(const char* filename);
+}
+
+extern IsReadyCallbackFn IsReadyCallback;

--- a/src/hacks.h
+++ b/src/hacks.h
@@ -1,6 +1,7 @@
 #include "aimbot.h"
 #include "airstuck.h"
 #include "antiaim.h"
+#include "autoaccept.h"
 #include "autostrafe.h"
 #include "bhop.h"
 #include "chams.h"

--- a/src/hooker.cpp
+++ b/src/hooker.cpp
@@ -39,6 +39,8 @@ CMoveData* g_MoveData = nullptr;
 GlowObjectManagerFn GlowObjectManager;
 MsgFunc_ServerRankRevealAllFn MsgFunc_ServerRankRevealAll;
 SendClanTagFn SendClanTag;
+IsReadyCallbackFn IsReadyCallback;
+
 RecvVarProxyFn fnSequenceProxyFn;
 
 std::unordered_map<const char*, uintptr_t> GetProcessLibraries() {
@@ -161,4 +163,11 @@ void Hooker::HookPrediction()
 	nPredictionRandomSeed = *reinterpret_cast<int**>(GetAbsoluteAddress(seed_instruction_addr, 3, 7));
 	movehelper = *reinterpret_cast<IMoveHelper**>(GetAbsoluteAddress(helper_instruction_addr + 1, 3, 7));
 	g_MoveData = **reinterpret_cast<CMoveData***>(GetAbsoluteAddress(movedata_instruction_addr, 3, 7));
+}
+
+void Hooker::HookIsReadyCallback()
+{
+	uintptr_t func_address = FindPattern(GetLibraryAddress("client_client.so"), 0xFFFFFFFFF, (unsigned char*) ISREADY_CALLBACK_SIGNATURE, ISREADY_CALLBACK_MASK);
+	
+	IsReadyCallback = reinterpret_cast<IsReadyCallbackFn>(func_address);
 }

--- a/src/hooker.h
+++ b/src/hooker.h
@@ -27,6 +27,9 @@
 #define CLIENT_MOVEDATA_SIGNATURE "\x48\x8B\x0D\x00\x00\x00\x00\x4C\x89\xF2"
 #define CLIENT_MOVEDATA_MASK "xxx????xxx"
 
+#define ISREADY_CALLBACK_SIGNATURE "\x48\x83\x3D\x00\x00\x00\x00\x00\x55\x48\x89\xE5\x41"
+#define ISREADY_CALLBACK_MASK "xxx????xxxxxx"
+
 #include <unordered_map>
 #include <sys/mman.h>
 #include <link.h>
@@ -47,5 +50,6 @@ namespace Hooker
 	void HookViewRender();
 	void HookSendPacket();
 	void HookPrediction();
+	void HookIsReadyCallback();
 	void UnhookSendPacket();
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -256,6 +256,8 @@ void Settings::LoadDefaultsOrSave(const char* filename)
 
 	settings["FakeLag"]["enabled"] = Settings::FakeLag::enabled;
 
+	settings["AutoAccept"]["enabled"] = Settings::AutoAccept::enabled;
+
 	std::ofstream(GetSettingsPath(filename)) << styledWriter.write(settings);
 }
 
@@ -456,4 +458,6 @@ void Settings::LoadSettings(const char* filename)
 	GetButtonCode(settings["Teleport"]["key"], &Settings::Teleport::key);
 
 	GetBool(settings["FakeLag"]["enabled"], &Settings::FakeLag::enabled);
+	
+	GetBool(settings["AutoAccept"]["enabled"], &Settings::AutoAccept::enabled);
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -425,6 +425,11 @@ namespace Settings
 		extern int value;
 	}
 
+	namespace AutoAccept
+	{
+		extern bool enabled;
+	}
+
 	void LoadDefaultsOrSave(const char* filename);
 	void LoadSettings(const char* filename);
 }


### PR DESCRIPTION
The accept button still shows up but the game will be accepted and you'll be able to see how many other players have also accepted the game. Not as clean as the Windows version but it should work perfectly.

Re: #168