### PR TITLE
Automatically unscope if there is no entity in sight while autoscope is on

### DIFF
--- a/src/aimbot.cpp
+++ b/src/aimbot.cpp
@@ -340,6 +340,7 @@ void Aimbot::AutoShoot(C_BaseEntity* entity, C_BaseCombatWeapon* active_weapon, 
 		return;
 
 	C_BasePlayer* localplayer = (C_BasePlayer*)entitylist->GetClientEntity(engine->GetLocalPlayer());
+
 	float nextPrimaryAttack = active_weapon->GetNextPrimaryAttack();
 	float tick = localplayer->GetTickBase() * globalvars->interval_per_tick;
 
@@ -402,6 +403,7 @@ void Aimbot::CreateMove(CUserCmd* cmd)
 	shouldAim = Settings::Aimbot::AutoShoot::enabled;
 
 	C_BasePlayer* localplayer = (C_BasePlayer*)entitylist->GetClientEntity(engine->GetLocalPlayer());
+
 	if (!localplayer || !localplayer->GetAlive())
 		return;
 
@@ -411,6 +413,7 @@ void Aimbot::CreateMove(CUserCmd* cmd)
 
 	Bone aw_bone;
 	C_BaseEntity* entity = GetClosestEnemy(cmd, true, aw_bone);
+
 	if (entity && Settings::Aimbot::AutoAim::enabled)
 	{
 		if (cmd->buttons & IN_ATTACK && !Settings::Aimbot::aimkey_only)
@@ -445,4 +448,7 @@ void Aimbot::CreateMove(CUserCmd* cmd)
 
 	if (!Settings::Aimbot::silent)
 		engine->SetViewAngles(cmd->viewangles);
+
+	if (Settings::Aimbot::AutoShoot::autoscope && localplayer->IsScoped() && !entity)
+                cmd->buttons |= IN_ATTACK2;
 }


### PR DESCRIPTION
Workaround for #159  I'd add this as another setting but I don't have time right now because holidays.