### PR TITLE
Add ability to apply glow to custom entities.

### DIFF
--- a/src/Hooks/FrameStageNotify.cpp
+++ b/src/Hooks/FrameStageNotify.cpp
@@ -2,6 +2,7 @@
 
 void Hooks::FrameStageNotify(void* thisptr, ClientFrameStage_t stage)
 {
+	CustomGlow::FrameStageNotify(stage);
 	SkinChanger::FrameStageNotify(stage);
 	Noflash::FrameStageNotify(stage);
 	View::FrameStageNotify(stage);

--- a/src/SDK/CGlowObjectManager.h
+++ b/src/SDK/CGlowObjectManager.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// Special values for GlowObjectDefinition_t::m_nNextFreeSlot
+#define END_OF_FREE_LIST -1
+#define ENTRY_IN_USE -2
+
 struct GlowObjectDefinition_t {
 	C_BaseEntity* m_pEntity;
 	float m_flGlowColor[3];
@@ -16,17 +20,14 @@ struct GlowObjectDefinition_t {
 	int iUnk;
 	int m_nSplitScreenSlot;
 	int m_nNextFreeSlot;
+
+	bool IsUnused() const {
+		return m_nNextFreeSlot != ENTRY_IN_USE;
+	}
 };
 
-struct CGlowObjectManager {
-	GlowObjectDefinition_t* m_GlowObjectDefinitions;
-	int max_size;
-	int pad;
-	int size;
-	GlowObjectDefinition_t* m_GlowObjectDefinitions2;
-	int currentObjects;
+class CGlowObjectManager {
+public:
+	CUtlVector<GlowObjectDefinition_t> m_GlowObjectDefinitions;
+	int m_nFirstFreeSlot;
 };
-
-// Special values for GlowObjectDefinition_t::m_nNextFreeSlot
-#define END_OF_FREE_LIST -1
-#define ENTRY_IN_USE -2

--- a/src/SDK/CGlowObjectManager.h
+++ b/src/SDK/CGlowObjectManager.h
@@ -28,6 +28,41 @@ struct GlowObjectDefinition_t {
 
 class CGlowObjectManager {
 public:
+	int RegisterGlowObject(C_BaseEntity* entity) {
+		// FIXME: No remaining slots, see issue #158.
+		if (m_nFirstFreeSlot == END_OF_FREE_LIST)
+			return -1;
+
+		int index = m_nFirstFreeSlot;
+		m_nFirstFreeSlot = m_GlowObjectDefinitions[index].m_nNextFreeSlot;
+		
+		m_GlowObjectDefinitions[index].m_pEntity = entity;
+		m_GlowObjectDefinitions[index].flUnk = 0.0f;
+		m_GlowObjectDefinitions[index].localplayeriszeropoint3 = 0.0f;
+		m_GlowObjectDefinitions[index].m_bFullBloomRender = false;
+		m_GlowObjectDefinitions[index].m_nFullBloomStencilTestValue = 0;
+		m_GlowObjectDefinitions[index].m_nSplitScreenSlot = -1;
+		m_GlowObjectDefinitions[index].m_nNextFreeSlot = ENTRY_IN_USE;
+
+		return index;
+	}
+
+	void UnregisterGlowObject(int index) {
+		m_GlowObjectDefinitions[index].m_nNextFreeSlot = m_nFirstFreeSlot;
+		m_GlowObjectDefinitions[index].m_pEntity = NULL;
+		m_nFirstFreeSlot = index;
+	}
+
+	bool HasGlowEffect(C_BaseEntity* entity) {
+		for (int i = 0; i < m_GlowObjectDefinitions.Count(); ++i) {
+			if (!m_GlowObjectDefinitions[i].IsUnused() && m_GlowObjectDefinitions[i].m_pEntity == entity) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
 	CUtlVector<GlowObjectDefinition_t> m_GlowObjectDefinitions;
 	int m_nFirstFreeSlot;
 };

--- a/src/SDK/CUtlMemory.h
+++ b/src/SDK/CUtlMemory.h
@@ -1,0 +1,12 @@
+#pragma once
+
+template <class T, class I = int> class CUtlMemory {
+	public:
+		T& operator[](I i) {
+			return m_pMemory[i];
+		}
+	protected:
+		T* m_pMemory;
+		int m_nAllocationCount;
+		int m_nGrowSize;
+};

--- a/src/SDK/CUtlVector.h
+++ b/src/SDK/CUtlVector.h
@@ -1,0 +1,18 @@
+#pragma once
+
+template <class T, class A = CUtlMemory<T>> class CUtlVector {
+	typedef A CAllocator;
+
+	public:
+		T& operator[](int i) {
+			return m_Memory[i];
+		}
+		
+		int Count() const {
+			return m_Size;
+		}
+	protected:
+		CAllocator m_Memory;
+		int m_Size;
+		T* m_pElements;
+};

--- a/src/SDK/IClientEntity.h
+++ b/src/SDK/IClientEntity.h
@@ -104,6 +104,11 @@ public:
 	{
 		return *(int*)((uintptr_t)this + offsets.DT_CSPlayer.m_bHasHelmet);
 	}
+
+	int HasDefuser()
+	{
+		return *(int*)((uintptr_t)this + offsets.DT_CSPlayer.m_bHasDefuser);
+	}
 	
 	int GetTeam()
 	{

--- a/src/SDK/SDK.h
+++ b/src/SDK/SDK.h
@@ -27,6 +27,8 @@
 #include "IClientMode.h"
 #include "ICvar.h"
 #include "IGameEvent.h"
+#include "CUtlMemory.h"
+#include "CUtlVector.h"
 #include "CGlowObjectManager.h"
 #include "IPhysicsSurfaceProps.h"
 #include "CViewRender.h"

--- a/src/SDK/definitions.h
+++ b/src/SDK/definitions.h
@@ -28,6 +28,14 @@ struct WeaponInfo_t {
 	float m_flRangeModifier;
 };
 
+enum TeamID: int
+{
+	TEAM_UNASSIGNED,
+	TEAM_SPECTATOR,
+	TEAM_TERRORIST,
+	TEAM_COUNTER_TERRORIST,
+};
+
 enum class FontFeature: int
 {
 	FONT_FEATURE_ANTIALIASED_FONTS = 1,

--- a/src/customglow.cpp
+++ b/src/customglow.cpp
@@ -1,0 +1,36 @@
+#include "customglow.h"
+
+std::vector<std::pair<int, int>> custom_glow_entities;
+
+void CustomGlow::FrameStageNotify(ClientFrameStage_t stage)
+{
+	if (stage != ClientFrameStage_t::FRAME_RENDER_START)
+		return;
+
+	// Skip reserved slots that are guaranteed to be managed by the engine.
+	for (int i = 64; i < entitylist->GetHighestEntityIndex(); i++) {
+		C_BaseEntity* entity = reinterpret_cast<C_BaseEntity*>(entitylist->GetClientEntity(i));
+
+		// Register custom entities into the glow object definitions array.
+		if (entity && entity->GetClientClass()->m_ClassID == CBaseAnimating) {
+			if (!glowmanager->HasGlowEffect(entity)) {
+				int array_index = glowmanager->RegisterGlowObject(entity);
+
+				if (array_index != -1)
+					custom_glow_entities.emplace_back(i, array_index);
+			}
+		} else {
+			// Remove any entities that no longer exist.
+			auto iterator = std::find_if(custom_glow_entities.begin(), custom_glow_entities.end(),
+				[&] (const std::pair<int, int>& p) {
+					return p.first == i;
+				}
+			);
+
+			if (iterator != custom_glow_entities.end()) {
+				glowmanager->UnregisterGlowObject(iterator->second);
+				custom_glow_entities.erase(iterator);
+			}
+		}
+	}
+}

--- a/src/customglow.cpp
+++ b/src/customglow.cpp
@@ -4,9 +4,6 @@ std::vector<std::pair<int, int>> custom_glow_entities;
 
 void CustomGlow::FrameStageNotify(ClientFrameStage_t stage)
 {
-	if (stage != ClientFrameStage_t::FRAME_RENDER_START)
-		return;
-
 	// Skip reserved slots that are guaranteed to be managed by the engine.
 	for (int i = 64; i < entitylist->GetHighestEntityIndex(); i++) {
 		C_BaseEntity* entity = reinterpret_cast<C_BaseEntity*>(entitylist->GetClientEntity(i));

--- a/src/customglow.h
+++ b/src/customglow.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "SDK/SDK.h"
+#include "interfaces.h"
+#include "settings.h"
+
+namespace CustomGlow
+{
+    void FrameStageNotify(ClientFrameStage_t stage);
+}

--- a/src/esp.cpp
+++ b/src/esp.cpp
@@ -368,7 +368,7 @@ void ESP::DrawGlow()
 		{
 			color = Settings::ESP::Glow::defuser_color;
 
-			if (localplayer->HasDefuser())
+			if (localplayer->HasDefuser() || localplayer->GetTeam() == TEAM_TERRORIST)
 				should_glow = false;
 		}
 

--- a/src/esp.cpp
+++ b/src/esp.cpp
@@ -14,6 +14,7 @@ Color Settings::ESP::Glow::enemy_color = Color(200, 0, 50, 0);
 Color Settings::ESP::Glow::enemy_visible_color = Color(200, 200, 50, 0);
 Color Settings::ESP::Glow::weapon_color = Color(200, 0, 50, 200);
 Color Settings::ESP::Glow::grenade_color = Color(200, 0, 50, 200);
+Color Settings::ESP::Glow::defuser_color = Color(100, 100, 200, 200);
 bool Settings::ESP::visibility_check = false;
 bool Settings::ESP::show_scope_border = true;
 bool Settings::ESP::Walls::enabled = false;
@@ -332,6 +333,7 @@ void ESP::DrawGlow()
 
 		Color color;
 		ClientClass* client = glow_object.m_pEntity->GetClientClass();
+		bool should_glow = true;
 
 		if (client->m_ClassID == CCSPlayer)
 		{
@@ -362,11 +364,18 @@ void ESP::DrawGlow()
 		{
 			color = Settings::ESP::Glow::grenade_color;
 		}
+		else if (client->m_ClassID == CBaseAnimating)
+		{
+			color = Settings::ESP::Glow::defuser_color;
+
+			if (localplayer->HasDefuser())
+				should_glow = false;
+		}
 
 		glow_object.m_flGlowColor[0] = color.r / 255.0f;
 		glow_object.m_flGlowColor[1] = color.g / 255.0f;
 		glow_object.m_flGlowColor[2] = color.b / 255.0f;
-		glow_object.m_flGlowAlpha = color.a / 255.0f;
+		glow_object.m_flGlowAlpha = should_glow ? color.a / 255.0f : 0.f;
 		glow_object.m_flBloomAmount = 1.0f;
 		glow_object.m_bRenderWhenOccluded = true;
 		glow_object.m_bRenderWhenUnoccluded = false;

--- a/src/esp.cpp
+++ b/src/esp.cpp
@@ -320,31 +320,29 @@ void ESP::DrawWeaponText(C_BaseEntity* entity, ClientClass* client)
 
 void ESP::DrawGlow()
 {
-	static CGlowObjectManager* glow_object_mgr = GlowObjectManager();
-
 	C_BasePlayer* localplayer = (C_BasePlayer*)entitylist->GetClientEntity(engine->GetLocalPlayer());
 	if (!localplayer)
 		return;
 
-	for (int i = 0; i < glow_object_mgr->max_size; i++) {
-		auto glow_object = &glow_object_mgr->m_GlowObjectDefinitions[i];
+	for (int i = 0; i < glowmanager->m_GlowObjectDefinitions.Count(); i++) {
+		GlowObjectDefinition_t& glow_object = glowmanager->m_GlowObjectDefinitions[i];
 
-		if (!glow_object || glow_object->m_nNextFreeSlot != ENTRY_IN_USE || !glow_object->m_pEntity)
+		if (glow_object.IsUnused() || !glow_object.m_pEntity)
 			continue;
 
 		Color color;
-		ClientClass* client = glow_object->m_pEntity->GetClientClass();
+		ClientClass* client = glow_object.m_pEntity->GetClientClass();
 
 		if (client->m_ClassID == CCSPlayer)
 		{
-			if (glow_object->m_pEntity == (C_BaseEntity*)localplayer
-				|| glow_object->m_pEntity->GetDormant()
-				|| !glow_object->m_pEntity->GetAlive())
+			if (glow_object.m_pEntity == (C_BaseEntity*)localplayer
+				|| glow_object.m_pEntity->GetDormant()
+				|| !glow_object.m_pEntity->GetAlive())
 				continue;
 
-			if (glow_object->m_pEntity->GetTeam() != localplayer->GetTeam())
+			if (glow_object.m_pEntity->GetTeam() != localplayer->GetTeam())
 			{
-				if (Entity::IsVisible(glow_object->m_pEntity, BONE_HEAD))
+				if (Entity::IsVisible(glow_object.m_pEntity, BONE_HEAD))
 					color = Settings::ESP::Glow::enemy_visible_color;
 				else
 					color = Settings::ESP::Glow::enemy_color;
@@ -365,13 +363,13 @@ void ESP::DrawGlow()
 			color = Settings::ESP::Glow::grenade_color;
 		}
 
-		glow_object->m_flGlowColor[0] = color.r / 255.0f;
-		glow_object->m_flGlowColor[1] = color.g / 255.0f;
-		glow_object->m_flGlowColor[2] = color.b / 255.0f;
-		glow_object->m_flGlowAlpha = color.a / 255.0f;
-		glow_object->m_flBloomAmount = 1.0f;
-		glow_object->m_bRenderWhenOccluded = true;
-		glow_object->m_bRenderWhenUnoccluded = false;
+		glow_object.m_flGlowColor[0] = color.r / 255.0f;
+		glow_object.m_flGlowColor[1] = color.g / 255.0f;
+		glow_object.m_flGlowColor[2] = color.b / 255.0f;
+		glow_object.m_flGlowAlpha = color.a / 255.0f;
+		glow_object.m_flBloomAmount = 1.0f;
+		glow_object.m_bRenderWhenOccluded = true;
+		glow_object.m_bRenderWhenUnoccluded = false;
 	}
 }
 

--- a/src/esp.h
+++ b/src/esp.h
@@ -21,5 +21,3 @@ namespace ESP
 	bool PrePaintTraverse(VPANEL vgui_panel, bool force_repaint, bool allow_force);
 	void PaintTraverse(VPANEL vgui_panel, bool force_repaint, bool allow_force);
 }
-
-extern GlowObjectManagerFn GlowObjectManager;

--- a/src/hacks.h
+++ b/src/hacks.h
@@ -6,6 +6,7 @@
 #include "bhop.h"
 #include "chams.h"
 #include "clantagchanger.h"
+#include "customglow.h"
 #include "dlights.h"
 #include "esp.h"
 #include "fakelag.h"

--- a/src/hooker.cpp
+++ b/src/hooker.cpp
@@ -22,6 +22,7 @@ CViewRender* viewrender = nullptr;
 IPrediction* prediction = nullptr;
 IGameMovement* gamemovement = nullptr;
 IMoveHelper* movehelper = nullptr;
+CGlowObjectManager* glowmanager = nullptr;
 
 VMT* panel_vmt = nullptr;
 VMT* client_vmt = nullptr;
@@ -36,7 +37,6 @@ bool* bSendPacket = nullptr;
 int* nPredictionRandomSeed = nullptr;
 CMoveData* g_MoveData = nullptr;
 
-GlowObjectManagerFn GlowObjectManager;
 MsgFunc_ServerRankRevealAllFn MsgFunc_ServerRankRevealAll;
 SendClanTagFn SendClanTag;
 IsReadyCallbackFn IsReadyCallback;
@@ -121,7 +121,7 @@ void Hooker::HookGlowManager()
 {
 	uintptr_t instruction_addr = FindPattern(GetLibraryAddress("client_client.so"), 0xFFFFFFFFF, (unsigned char*) GLOWOBJECT_SIGNATURE, GLOWOBJECT_MASK);
 
-	GlowObjectManager = reinterpret_cast<GlowObjectManagerFn>(GetAbsoluteAddress(instruction_addr, 1, 5));
+	glowmanager = reinterpret_cast<GlowObjectManagerFn>(GetAbsoluteAddress(instruction_addr, 1, 5))();
 }
 
 void Hooker::HookRankReveal()

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -24,6 +24,7 @@ extern IPhysicsSurfaceProps* physics;
 extern IPrediction* prediction;
 extern IGameMovement* gamemovement;
 extern IMoveHelper* movehelper;
+extern CGlowObjectManager* glowmanager;
 
 extern VMT* panel_vmt;
 extern VMT* client_vmt;

--- a/src/offsets.cpp
+++ b/src/offsets.cpp
@@ -43,6 +43,7 @@ void Offsets::getOffsets()
 	offsets.DT_CSPlayer.m_bIsScoped = NetVarManager::getOffset(tables, "DT_CSPlayer", "m_bIsScoped");
 	offsets.DT_CSPlayer.m_bGunGameImmunity = NetVarManager::getOffset(tables, "DT_CSPlayer", "m_bGunGameImmunity");
 	offsets.DT_CSPlayer.m_bHasHelmet = NetVarManager::getOffset(tables, "DT_CSPlayer", "m_bHasHelmet");
+	offsets.DT_CSPlayer.m_bHasDefuser = NetVarManager::getOffset(tables, "DT_CSPlayer", "m_bHasDefuser");
 	offsets.DT_CSPlayer.m_flFlashMaxAlpha = NetVarManager::getOffset(tables, "DT_CSPlayer", "m_flFlashMaxAlpha");
 
 	offsets.DT_BaseAttributableItem.m_iItemDefinitionIndex = NetVarManager::getOffset(tables, "DT_BaseAttributableItem", "m_iItemDefinitionIndex");

--- a/src/offsets.h
+++ b/src/offsets.h
@@ -55,6 +55,7 @@ struct COffsets
 		int m_bIsScoped;
 		int m_bGunGameImmunity;
 		int m_bHasHelmet;
+		int m_bHasDefuser;
 		int m_flFlashMaxAlpha;
 	} DT_CSPlayer;
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -163,6 +163,7 @@ void Settings::LoadDefaultsOrSave(Config config)
 	LoadColor(settings["ESP"]["Glow"]["enemy_visible_color"], Settings::ESP::Glow::enemy_visible_color);
 	LoadColor(settings["ESP"]["Glow"]["weapon_color"], Settings::ESP::Glow::weapon_color);
 	LoadColor(settings["ESP"]["Glow"]["grenade_color"], Settings::ESP::Glow::grenade_color);
+	LoadColor(settings["ESP"]["Glow"]["defuser_color"], Settings::ESP::Glow::defuser_color);
 	settings["ESP"]["Tracer"]["enabled"] = Settings::ESP::Tracer::enabled;
 	settings["ESP"]["Tracer"]["type"] = Settings::ESP::Tracer::type;
 	settings["ESP"]["Walls"]["enabled"] = Settings::ESP::Walls::enabled;
@@ -350,6 +351,7 @@ void Settings::LoadConfig(Config config)
 	GetColor(settings["ESP"]["Glow"]["enemy_visible_color"], &Settings::ESP::Glow::enemy_visible_color);
 	GetColor(settings["ESP"]["Glow"]["weapon_color"], &Settings::ESP::Glow::weapon_color);
 	GetColor(settings["ESP"]["Glow"]["grenade_color"], &Settings::ESP::Glow::grenade_color);
+	GetColor(settings["ESP"]["Glow"]["defuser_color"], &Settings::ESP::Glow::defuser_color);
 	GetBool(settings["ESP"]["Tracer"]["enabled"], &Settings::ESP::Tracer::enabled);
 	GetInt(settings["ESP"]["Tracer"]["type"], &Settings::ESP::Tracer::type);
 	GetBool(settings["ESP"]["Walls"]["enabled"], &Settings::ESP::Walls::enabled);

--- a/src/settings.h
+++ b/src/settings.h
@@ -240,6 +240,7 @@ namespace Settings
 			extern Color enemy_visible_color;
 			extern Color weapon_color;
 			extern Color grenade_color;
+			extern Color defuser_color;
 		}
 
 		namespace Tracer


### PR DESCRIPTION
As requested in #158, this will apply a glow effect to dropped defuser kit entities while playing on the CT side without a kit. If there are too many entities already in the glow definition list it won't grow the vector, as this [doesn't seem to make any difference](https://www.unknowncheats.me/forum/1588459-post6.html).

I've replaced the existing glow manager class with a proper CUtlVector and CUtlMemory implementation just in case some progress is made further down the line in that area.

The defuser check is a simple class comparison for CBaseAnimating. This should be fine on official servers but might cause some issues on community servers if they use custom entities with this class.

I had some issues with crashing when calling CustomGlow during `FRAME_RENDER_START` only, I can't reproduce this now when calling it during all stages so please test this before merging. Create some kits with  `ent_create item_defuser`, respawn and switch teams a few times. Post any backtraces if the game crashes.