### PR TITLE
Added BombESP damage indicator

### DIFF
--- a/src/esp.cpp
+++ b/src/esp.cpp
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "esp.h"
 #include "settings.h"
 
@@ -282,11 +283,30 @@ void ESP::DrawFOVCrosshair()
 	Draw::DrawCircle(LOC(width / 2, height / 2), 20, circleRadius, Color(255, 100, 100, 255));
 }
 
+//credits to Casual_Hacker from UC for this method (I modified it a lil bit)
+float ESP::GetArmourHealth(float flDamage, int ArmorValue)
+{
+	float flCurDamage = flDamage;
+	if (flCurDamage == 0.0f || ArmorValue == 0)
+		return flCurDamage;
+	float flArmorRatio = 0.5f;
+	float flArmorBonus = 0.5f;
+	float flNew = flCurDamage * flArmorRatio;
+	float flArmor = (flCurDamage - flNew) * flArmorBonus;
+
+	if (flArmor > ArmorValue) {
+		flArmor = ArmorValue * (1.0f / flArmorBonus);
+		flNew = flCurDamage - flArmor;
+	}
+
+	return flNew;
+}  
+
 void ESP::DrawBombBox(C_BasePlantedC4* entity)
 {
+	C_BasePlayer* localplayer = (C_BasePlayer*)entitylist->GetClientEntity(engine->GetLocalPlayer());
 	Color color = Settings::ESP::bomb_color;
-	Color colorText = entity->GetBombDefuser() != -1 ? Color(0, 50, 200) : Color(255, 255, 255);
-
+	
 	int width = 7;
 	int additionalHeight = 4;
 	float bombTime = entity->GetBombTime() - globalvars->curtime;
@@ -296,12 +316,25 @@ void ESP::DrawBombBox(C_BasePlantedC4* entity)
 
 	pstring str = "C4";
 
+	float flDistance = sqrt(localplayer->GetEyePosition().DistToSqr(vecOrigin));
+
+	float a = 450.7f;
+	float b = 75.68f;
+	float c = 789.2f;
+	float d = ((flDistance - b) / c);
+	float flDamage = a*exp(-d * d);
+
+	float damage = std::max((int)ceilf(ESP::GetArmourHealth(flDamage, localplayer->GetArmor())), 0);  
+
+	bool surviveBlast = localplayer->GetHealth() > damage;
+
 	if (bombTime > 0)
-		str << " (" << bombTime << ")";
+		str << " (" << bombTime << ", " << damage << "hp)";
 
 	Vector s_veclocalplayer_s;
 	if (!WorldToScreen(vecOrigin, s_veclocalplayer_s))
 	{
+		Color colorText = entity->GetBombDefuser() != -1 ? Color(0, 50, 200) : surviveBlast ? Color(255, 255, 255) : Color(255, 0, 0);
 		DrawESPBox(vecOrigin, vecViewOffset, color, width, additionalHeight);
 		Draw::DrawCenteredString(str.c_str(), LOC(s_veclocalplayer_s.x, s_veclocalplayer_s.y), colorText, esp_font);
 	}

--- a/src/esp.h
+++ b/src/esp.h
@@ -13,6 +13,7 @@ namespace ESP
 	void DrawTracer(C_BaseEntity* entity);
 	void DrawPlayerBox(C_BaseEntity* entity);
 	void DrawPlayerInfo(C_BaseEntity* entity, int entityIndex);
+	float GetArmourHealth(float flDamage, int ArmorValue);
 	void DrawBombBox(C_BasePlantedC4* entity);
 	void DrawWeaponText(C_BaseEntity* entity, ClientClass* client);
 	void DrawBones(C_BaseEntity* entity);


### PR DESCRIPTION
This tells you how much damage you will take from the bomb exploding. Armour is taking into account, and you can easily tell if you will die because the text will go red if the damage taken is more than the player's health (defusing will still make it go blue however).