### PR TITLE
GetInterface fixes and interface dumping

### DIFF
--- a/src/AimTux.cpp
+++ b/src/AimTux.cpp
@@ -7,6 +7,8 @@
 /* called when the library is loading */
 int __attribute__((constructor)) aimtux_init()
 {
+	Interfaces::dumpInterfaces();
+
 	Hooker::HookInterfaces();
 	Hooker::HookViewRender();
 	Hooker::HookSDLInput();
@@ -60,7 +62,7 @@ int __attribute__((constructor)) aimtux_init()
 
 	launchermgr_vmt->HookVM((void*) Hooks::PumpWindowsMessageLoop, 19);
 	launchermgr_vmt->ApplyVMT();
-	
+
 	enginevgui_vmt->HookVM((void*) Hooks::Paint, 15);
 	enginevgui_vmt->ApplyVMT();
 

--- a/src/SDK/common.h
+++ b/src/SDK/common.h
@@ -1,6 +1,14 @@
 #pragma once
 #include <cstring>
 
+struct interface_t
+{
+	typedef void* (*InstantiateInterfaceFn)();
+	InstantiateInterfaceFn m_CreateFn;
+	const char *m_pName;
+	interface_t *m_pNext;
+};
+
 inline void**& getvtable(void* inst, size_t offset = 0)
 {
 	return *reinterpret_cast<void***>((size_t)inst + offset);
@@ -25,18 +33,12 @@ interface* GetInterface(const char* filename, const char* version, bool exact = 
 	if (!library)
 		return nullptr;
 
-	struct interface_t
-	{
-		typedef void* (*InstantiateInterfaceFn)();
-		InstantiateInterfaceFn m_CreateFn;
-		const char *m_pName;
-		interface_t *m_pNext;
-	};
+	void* interfaces_sym = dlsym(library, "s_pInterfaceRegs");
 
-	interface_t* interfaces = *reinterpret_cast<interface_t**>(dlsym(library, "s_pInterfaceRegs"));
-
-	if (!interfaces)
+	if (!interfaces_sym)
 		return nullptr;
+
+	interface_t* interfaces = *reinterpret_cast<interface_t**>(interfaces_sym);
 
 	interface_t* cur_interface;
 

--- a/src/interfaces.cpp
+++ b/src/interfaces.cpp
@@ -1,0 +1,56 @@
+#include <unordered_map>
+#include <set>
+#include "interfaces.h"
+#include "hooker.h"
+
+void Interfaces::dumpInterfaces()
+{
+	std::stringstream ss;
+	char cwd[1024];
+
+	std::vector<const char*> modules;
+
+	dl_iterate_phdr([](struct dl_phdr_info* info, size_t size, void* data) {
+		reinterpret_cast<std::vector<const char*>*>(data)->push_back(info->dlpi_name);
+		return 0;
+	}, &modules);
+
+	for (auto module : modules)
+	{
+		void* library = dlopen(module, RTLD_NOLOAD | RTLD_NOW);
+
+		if (!library)
+			continue;
+
+		void* interfaces_sym = dlsym(library, "s_pInterfaceRegs");
+
+		if (!interfaces_sym)
+			continue;
+
+		interface_t* interfaces = *reinterpret_cast<interface_t**>(interfaces_sym);
+
+		interface_t* cur_interface;
+
+		std::set<const char*> interface_name;
+
+		for (cur_interface = interfaces; cur_interface; cur_interface = cur_interface->m_pNext)
+			interface_name.insert(cur_interface->m_pName);
+
+		if (interface_name.empty())
+			continue;
+
+		ss << std::string(module) << "\n";
+
+		for (auto interface : interface_name)
+			ss << "\t" << interface << "\n";
+
+		ss << '\n';
+	}
+
+	getcwd(cwd, sizeof(cwd));
+
+	char* interfacesPath;
+	asprintf(&interfacesPath, "%s/interfaces.txt", cwd);
+
+	std::ofstream(interfacesPath) << ss.str();
+}

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -52,3 +52,7 @@ extern uintptr_t* swap_window_jump_address;
 
 extern uintptr_t original_pollevent;
 extern uintptr_t* pollevent_jump_address;
+
+namespace Interfaces {
+	void dumpInterfaces();
+}


### PR DESCRIPTION
- GetInterface will now check for nullptr before casting
- Implement interface dumping (dumps to game_root/interface.txt)