### PR TITLE
Improved radar and various fixes

### DIFF
--- a/src/Hooks/BeginFrame.cpp
+++ b/src/Hooks/BeginFrame.cpp
@@ -6,6 +6,7 @@ void Hooks::BeginFrame(void* thisptr, float frameTime)
 	ClanTagChanger::BeginFrame(frameTime);
 	NameChanger::BeginFrame(frameTime);
 	Spammer::BeginFrame(frameTime);
+	Radar::BeginFrame();
 
 	if (!engine->IsInGame())
 	{

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1,6 +1,7 @@
 #include "entity.h"
+#include "math.h"
 
-bool Entity::IsVisible(C_BasePlayer* player, int bone)
+bool Entity::IsVisible(C_BasePlayer* player, int bone, float fov)
 {
 	C_BasePlayer* localplayer = (C_BasePlayer*) entitylist->GetClientEntity(engine->GetLocalPlayer());
 	if (!localplayer)
@@ -17,6 +18,13 @@ bool Entity::IsVisible(C_BasePlayer* player, int bone)
 
 	Vector e_vecHead = player->GetBonePosition(bone);
 	Vector p_vecHead = localplayer->GetEyePosition();
+
+	QAngle viewAngles;
+	engine->GetViewAngles(viewAngles);
+
+	// FIXME: scale fov by distance? its not really working that well...
+	if (Math::GetFov(viewAngles, Math::CalcAngle(p_vecHead, e_vecHead)) > fov)
+		return false;
 
 	Ray_t ray;
 	trace_t tr;

--- a/src/entity.h
+++ b/src/entity.h
@@ -6,7 +6,7 @@
 
 namespace Entity
 {
-	bool IsVisible(C_BasePlayer* player, int bone);
+	bool IsVisible(C_BasePlayer* player, int bone, float fov = 180.f);
 	bool IsPlanting(C_BasePlayer* player);
 	int GetBoneByName(C_BasePlayer* player, const char* boneName);
 }

--- a/src/esp.cpp
+++ b/src/esp.cpp
@@ -198,48 +198,28 @@ ImColor ESP::GetESPPlayerColor(C_BasePlayer* player, bool visible)
 
 	ImColor playerColor;
 
-	// dont actually check for visibility since we only render our boxes when the player IS visible (so-called "legit" mode)
-	if (Settings::ESP::Filters::legit)
+	if (Settings::ESP::team_color_type == TeamColorType::RELATIVE)
 	{
-		if (Settings::ESP::team_color_type == TeamColorType::RELATIVE)
-		{
-			playerColor = player->GetTeam() != localplayer->GetTeam() ? Settings::ESP::enemy_visible_color : Settings::ESP::ally_visible_color;
-		}
-		else if (Settings::ESP::team_color_type == TeamColorType::ABSOLUTE)
-		{
-			if (player->GetTeam() == TEAM_TERRORIST)
-				playerColor = Settings::ESP::t_visible_color;
+		if (player->GetTeam() != localplayer->GetTeam())
+			playerColor = visible ? Settings::ESP::enemy_visible_color : Settings::ESP::enemy_color;
+		else
+			playerColor = visible ? Settings::ESP::ally_visible_color  : Settings::ESP::ally_color;
 
-			else if (player->GetTeam() == TEAM_COUNTER_TERRORIST)
-				playerColor = Settings::ESP::ct_visible_color;
-		}
 	}
-	// check for visibility check
-	else
+	else if (Settings::ESP::team_color_type == TeamColorType::ABSOLUTE)
 	{
-		if (Settings::ESP::team_color_type == TeamColorType::RELATIVE)
-		{
-			if (player->GetTeam() != localplayer->GetTeam())
-				playerColor = visible ? Settings::ESP::enemy_visible_color : Settings::ESP::enemy_color;
-			else
-				playerColor = visible ? Settings::ESP::ally_visible_color  : Settings::ESP::ally_color;
+		if (player->GetTeam() == TEAM_TERRORIST)
+			playerColor = visible ? Settings::ESP::t_visible_color : Settings::ESP::t_color;
 
-		}
-		else if (Settings::ESP::team_color_type == TeamColorType::ABSOLUTE)
-		{
-			if (player->GetTeam() == TEAM_TERRORIST)
-				playerColor = visible ? Settings::ESP::t_visible_color : Settings::ESP::t_color;
-
-			else if (player->GetTeam() == TEAM_COUNTER_TERRORIST)
-				playerColor = visible ? Settings::ESP::ct_visible_color : Settings::ESP::ct_color;
-		}
+		else if (player->GetTeam() == TEAM_COUNTER_TERRORIST)
+			playerColor = visible ? Settings::ESP::ct_visible_color : Settings::ESP::ct_color;
 	}
 
 	if (player->GetImmune())
 	{
-		playerColor.Value.x -= 0.5f;
-		playerColor.Value.y -= 0.5f;
-		playerColor.Value.z -= 0.5f;
+		playerColor.Value.x *= 0.45f;
+		playerColor.Value.y *= 0.45f;
+		playerColor.Value.z *= 0.45f;
 	}
 
 	return playerColor;

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -11,7 +11,7 @@ bool Settings::Radar::visibility_check = false;
 
 std::set<int> visible_players;
 
-Vector2D WorldToRadar( const Vector location, const Vector origin, const QAngle angles, int width, float scale = 16.f)
+Vector2D WorldToRadar(const Vector location, const Vector origin, const QAngle angles, int width, float scale = 16.f)
 {
 	float x_diff = location.x - origin.x;
 	float y_diff = location.y - origin.y;

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -9,13 +9,14 @@ bool Settings::Radar::defuser = false;
 bool Settings::Radar::legit = false;
 bool Settings::Radar::visibility_check = false;
 
-Vector2D WorldToRadar( const Vector location, const Vector origin, const QAngle angles, int width, int scale = 16)
+std::set<int> visible_players;
+
+Vector2D WorldToRadar( const Vector location, const Vector origin, const QAngle angles, int width, float scale = 16.f)
 {
 	float x_diff = location.x - origin.x;
 	float y_diff = location.y - origin.y;
 
 	int iRadarRadius = width;
-	float fRange = scale * iRadarRadius;
 
 	float flOffset = atan(y_diff / x_diff);
 	flOffset *= 180;
@@ -39,20 +40,26 @@ Vector2D WorldToRadar( const Vector location, const Vector origin, const QAngle 
 	float xnew_diff = x_diff * cos(flOffset) - y_diff * sin(flOffset);
 	float ynew_diff = x_diff * sin(flOffset) + y_diff * cos(flOffset);
 
-	if (-1 * y_diff > fRange)
-	{
-		float flScale;
+	xnew_diff /= scale;
+	ynew_diff /= scale;
 
-		flScale = (-1 * y_diff) / fRange;
+	// clamp x & y
+	// FIXME: instead of using hardcoded "4" we should fix cliprect of the radar window
+	if ((iRadarRadius / 2) + (int) xnew_diff > iRadarRadius)
+		xnew_diff = iRadarRadius - 4;
+	else if ((iRadarRadius / 2) + (int) xnew_diff < 4)
+		xnew_diff = 4;
+	else
+		xnew_diff = (iRadarRadius / 2) + (int) xnew_diff;
 
-		xnew_diff /= flScale;
-		ynew_diff /= flScale;
-	}
+	if ((iRadarRadius / 2) + (int) ynew_diff > iRadarRadius)
+		ynew_diff = iRadarRadius;
+	else if ((iRadarRadius / 2) + (int) ynew_diff < 4)
+		ynew_diff = 0;
+	else
+		ynew_diff = (iRadarRadius / 2) + (int) ynew_diff;
 
-	xnew_diff /= scale * 2;
-	ynew_diff /= scale * 2;
-
-	return Vector2D((iRadarRadius / 2) + (int) xnew_diff, (iRadarRadius / 2) + (int) ynew_diff);
+	return Vector2D(xnew_diff, ynew_diff);
 }
 
 static void SquareConstraint(ImGuiSizeConstraintCallbackData *data)
@@ -112,7 +119,7 @@ void Radar::DrawWindow()
 
 			if (classId == CCSPlayer)
 			{
-				C_BasePlayer* player = (C_BasePlayer*) entitylist->GetClientEntity(i);
+				C_BasePlayer* player = (C_BasePlayer*) entity;
 
 				if (player == localplayer)
 					continue;
@@ -126,7 +133,7 @@ void Radar::DrawWindow()
 				if (player->GetTeam() != localplayer->GetTeam() && !Settings::Radar::enemies)
 					continue;
 
-				bool bIsVisible = player->GetTeam() == localplayer->GetTeam() || (Settings::Radar::visibility_check && (*player->GetSpotted() || Entity::IsVisible(player, BONE_HEAD)));
+				bool bIsVisible = player->GetTeam() == localplayer->GetTeam() || (Settings::Radar::visibility_check && (*player->GetSpotted() || std::find(visible_players.begin(), visible_players.end(), i) != visible_players.end()));
 				if (!bIsVisible && Settings::Radar::legit)
 					continue;
 
@@ -169,6 +176,9 @@ void Radar::DrawWindow()
 			}
 			else if (classId == CBaseAnimating)
 			{
+				if (!Settings::Radar::defuser)
+					continue;
+
 				if (localplayer->HasDefuser() || localplayer->GetTeam() != TEAM_COUNTER_TERRORIST)
 					continue;
 
@@ -187,15 +197,15 @@ void Radar::DrawWindow()
 											 color, 0.0f, 0);
 					break;
 				case EntityShape_t::SHAPE_TRIANGLE:
-					draw_list->AddTriangleFilled(ImVec2(winpos.x + screenpos.x, winpos.y + screenpos.y + 5.0f),
-												 ImVec2(winpos.x + screenpos.x + 5.0f, winpos.y + screenpos.y + 5.0f),
-												 ImVec2(winpos.x + screenpos.x + 2.5f, winpos.y + screenpos.y),
+					draw_list->AddTriangleFilled(ImVec2(winpos.x + screenpos.x, winpos.y + screenpos.y + 9.0f),
+												 ImVec2(winpos.x + screenpos.x + 9.0f, winpos.y + screenpos.y + 9.0f),
+												 ImVec2(winpos.x + screenpos.x + 5.f, winpos.y + screenpos.y),
 												 color);
 					break;
 				case EntityShape_t::SHAPE_TRIANGLE_UPSIDEDOWN:
 					draw_list->AddTriangleFilled(ImVec2(winpos.x + screenpos.x, winpos.y + screenpos.y),
-					                             ImVec2(winpos.x + screenpos.x + 5.0f, winpos.y + screenpos.y),
-					                             ImVec2(winpos.x + screenpos.x + 2.5f, winpos.y + screenpos.y + 5.0f),
+					                             ImVec2(winpos.x + screenpos.x + 9.0f, winpos.y + screenpos.y),
+					                             ImVec2(winpos.x + screenpos.x + 5.f, winpos.y + screenpos.y + 9.0f),
 					                             color);
 					break;
 			}
@@ -203,5 +213,33 @@ void Radar::DrawWindow()
 		}
 
 		ImGui::End();
+	}
+}
+
+void Radar::BeginFrame()
+{
+	if (!Settings::Radar::enabled)
+		return;
+
+	if (!engine->IsInGame())
+		return;
+
+	C_BasePlayer* localplayer = (C_BasePlayer*) entitylist->GetClientEntity(engine->GetLocalPlayer());
+	if (!localplayer)
+		return;
+
+	for (int i = 1; i < engine->GetMaxClients(); i++)
+	{
+		C_BaseEntity* entity = entitylist->GetClientEntity(i);
+		if (!entity)
+			continue;
+
+		C_BasePlayer* player = (C_BasePlayer*) entity;
+
+		// we shouldn't see people behind us
+		if (Entity::IsVisible(player, BONE_HEAD, 55.f))
+			visible_players.insert(i);
+		else
+			visible_players.erase(i);
 	}
 }

--- a/src/radar.h
+++ b/src/radar.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include "settings.h"
 #include "SDK/SDK.h"
 #include "interfaces.h"
@@ -14,4 +15,5 @@ namespace Radar
 		SHAPE_TRIANGLE_UPSIDEDOWN
 	};
 	void DrawWindow();
+	void BeginFrame();
 };


### PR DESCRIPTION
- Calling IEngineTrace::TraceRay outside game's threads causes crashes, move visibility checks to BeginFrame
- Triangles used in radar were too small compared to circles and squares
- Use proper border checks in WorldToRadar
- Remove useless and broken code from ESP::GetESPPlayerColor
- Change the way immune-color is computed
- Add fov parameter to Entity::IsVisible so that it can check whether player is visible within given field of view