### PR TITLE
Added autoblock

### DIFF
--- a/src/Hooks/CreateMove.cpp
+++ b/src/Hooks/CreateMove.cpp
@@ -17,6 +17,7 @@ bool Hooks::CreateMove(void* thisptr, float flInputSampleTime, CUserCmd* cmd)
 		ShowRanks::CreateMove(cmd);
 
 		PredictionSystem::StartPrediction(cmd);
+		Autoblock::CreateMove(cmd);
 		Aimbot::CreateMove(cmd);
 		Triggerbot::CreateMove(cmd);
 		AntiAim::CreateMove(cmd);

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -1163,6 +1163,10 @@ void MiscTab()
 				ImGui::Checkbox("AirStuck", &Settings::Airstuck::enabled);
 				if (ImGui::IsItemHovered())
 					ImGui::SetTooltip("Stops tickrate so you freeze in place");
+				ImGui::Checkbox("Autoblock", &Settings::Autoblock::enabled);
+				if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("Allows you to block players from moving forwards by standing in front of them and mirroring their moves - great for griefing");
+
 #ifdef UNTRUSTED_SETTINGS
 				ImGui::Checkbox("Teleport", &Settings::Teleport::enabled);
 				if (ImGui::IsItemHovered())
@@ -1176,6 +1180,7 @@ void MiscTab()
 				ImGui::PopItemWidth();
 				ImGui::Checkbox("Show Ranks", &Settings::ShowRanks::enabled);
 				UI::KeyBindButton(&Settings::Airstuck::key);
+				UI::KeyBindButton(&Settings::Autoblock::key);
 #ifdef UNTRUSTED_SETTINGS
 				UI::KeyBindButton(&Settings::Teleport::key);
 #endif

--- a/src/autoblock.cpp
+++ b/src/autoblock.cpp
@@ -1,0 +1,55 @@
+#include "autoblock.h"
+
+bool Settings::Autoblock::enabled = false;
+ButtonCode_t Settings::Autoblock::key = ButtonCode_t::KEY_6;
+
+//Thanks teamgamerfood!
+void Autoblock::CreateMove(CUserCmd* cmd)
+{
+	if (!Settings::Autoblock::enabled)
+		return;
+
+	if (input->IsButtonDown(Settings::Autoblock::key))
+	{
+		C_BasePlayer* localplayer = (C_BasePlayer*)entitylist->GetClientEntity(engine->GetLocalPlayer());
+		float bestdist = 250.f;
+		int index = -1;
+
+		for (int i = 1; i < engine->GetMaxClients(); ++i)
+		{
+			C_BasePlayer* entity = (C_BasePlayer*) entitylist->GetClientEntity(i);
+
+			if(!entity)
+				continue;
+
+			if(!entity->GetAlive() || entity->GetDormant() || entity == localplayer)
+				continue;
+
+			float dist = sqrtf(localplayer->GetVecOrigin().DistToSqr(entity->GetVecOrigin()));
+
+			if( dist < bestdist )
+			{
+				bestdist = dist;
+				index = i;
+			}
+		}
+ 
+		if( index == -1 )
+			return;
+
+		C_BasePlayer* target = (C_BasePlayer*) entitylist->GetClientEntity(index);
+
+		if( !target )
+			return;
+
+		QAngle angles = Math::CalcAngle(localplayer->GetVecOrigin(), target->GetVecOrigin());
+
+		angles.y -= localplayer->GetHeadRotation()->y;
+		Math::NormalizeAngles(angles);
+
+		if( angles.y < 0.0f )
+			cmd->sidemove = 450.f;
+		else if( angles.y > 0.0f )
+			cmd->sidemove = -450.f;
+	}
+}

--- a/src/autoblock.cpp
+++ b/src/autoblock.cpp
@@ -15,31 +15,31 @@ void Autoblock::CreateMove(CUserCmd* cmd)
 		float bestdist = 250.f;
 		int index = -1;
 
-		for (int i = 1; i < engine->GetMaxClients(); ++i)
+		for (int i = 1; i < engine->GetMaxClients(); i++)
 		{
 			C_BasePlayer* entity = (C_BasePlayer*) entitylist->GetClientEntity(i);
 
-			if(!entity)
+			if (!entity)
 				continue;
 
-			if(!entity->GetAlive() || entity->GetDormant() || entity == localplayer)
+			if (!entity->GetAlive() || entity->GetDormant() || entity == localplayer)
 				continue;
 
 			float dist = sqrtf(localplayer->GetVecOrigin().DistToSqr(entity->GetVecOrigin()));
 
-			if( dist < bestdist )
+			if (dist < bestdist)
 			{
 				bestdist = dist;
 				index = i;
 			}
 		}
  
-		if( index == -1 )
+		if (index == -1)
 			return;
 
 		C_BasePlayer* target = (C_BasePlayer*) entitylist->GetClientEntity(index);
 
-		if( !target )
+		if (!target)
 			return;
 
 		QAngle angles = Math::CalcAngle(localplayer->GetVecOrigin(), target->GetVecOrigin());
@@ -47,9 +47,9 @@ void Autoblock::CreateMove(CUserCmd* cmd)
 		angles.y -= localplayer->GetHeadRotation()->y;
 		Math::NormalizeAngles(angles);
 
-		if( angles.y < 0.0f )
+		if (angles.y < 0.0f)
 			cmd->sidemove = 450.f;
-		else if( angles.y > 0.0f )
+		else if (angles.y > 0.0f)
 			cmd->sidemove = -450.f;
 	}
 }

--- a/src/autoblock.h
+++ b/src/autoblock.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <climits>
+#include "settings.h"
+#include "SDK/SDK.h"
+#include "interfaces.h"
+
+namespace Autoblock
+{
+	void CreateMove(CUserCmd* cmd);
+}

--- a/src/hacks.h
+++ b/src/hacks.h
@@ -2,6 +2,7 @@
 #include "airstuck.h"
 #include "antiaim.h"
 #include "autoaccept.h"
+#include "autoblock.h"
 #include "autostrafe.h"
 #include "bhop.h"
 #include "chams.h"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -340,6 +340,9 @@ void Settings::LoadDefaultsOrSave(std::string path)
 
 	settings["NoScopeBorder"]["enabled"] = Settings::NoScopeBorder::enabled;
 
+	settings["Autoblock"]["enabled"] = Settings::Autoblock::enabled;
+	settings["Autoblock"]["key"] = Settings::Autoblock::key;
+
 	std::ofstream(path) << styledWriter.write(settings);
 }
 
@@ -620,6 +623,9 @@ void Settings::LoadConfig(std::string path)
 	GetUIColor(settings["ASUSWalls"]["color"], &Settings::ASUSWalls::color);
 
 	GetBool(settings["NoScopeBorder"]["enabled"], &Settings::NoScopeBorder::enabled);
+
+	GetBool(settings["Autoblock"]["enabled"], &Settings::Autoblock::enabled);
+	GetButtonCode(settings["Autoblock"]["key"], &Settings::Autoblock::key);
 }
 
 void Settings::LoadSettings()

--- a/src/settings.h
+++ b/src/settings.h
@@ -515,6 +515,12 @@ namespace Settings
 		extern ButtonCode_t key;
 	}
 
+	namespace Autoblock
+	{
+		extern bool enabled;
+		extern ButtonCode_t key;
+	}
+
 	namespace Skinchanger
 	{
 		struct Skin


### PR DESCRIPTION
An autoblock (sometimes referred to as a blocker or an autoblocker) can be used to block teammates. This works by mirroring your target's moves while facing them, so that they can not get past you. This can be useful for griefing teammates by trapping them in spawn if they are being annoying.

I have implemented the feature itself, and I have added it to the GUI in the miscellaneous section. The default keybind for it is 6 (this should really be changed to a different key - I have temporarily chosen this one because I know it's not used for anything else).

[Here](https://www.youtube.com/watch?v=Tvzz9qGLh-0) is a link to a similar autoblock in action.