### PR TITLE
Improve efficiency (muh CPU cycles)

### DIFF
--- a/src/SDK/vector.h
+++ b/src/SDK/vector.h
@@ -97,6 +97,7 @@ public:
 	}
 	Vector	Normalize();
 	float	NormalizeInPlace();
+	inline float	DistTo(const Vector &vOther) const;
 	inline float	DistToSqr(const Vector &vOther) const;
 	float	Dot(const Vector& vOther) const;
 	float	Length2D(void) const;
@@ -291,6 +292,16 @@ inline Vector CrossProduct(const Vector& a, const Vector& b)
 	return Vector(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);
 }
 //===============================================
+float Vector::DistTo(const Vector &vOther) const
+{
+	Vector delta;
+
+	delta.x = x - vOther.x;
+	delta.y = y - vOther.y;
+	delta.z = z - vOther.z;
+
+	return delta.Length();
+}
 float Vector::DistToSqr(const Vector &vOther) const
 {
 	Vector delta;

--- a/src/autoblock.cpp
+++ b/src/autoblock.cpp
@@ -25,7 +25,7 @@ void Autoblock::CreateMove(CUserCmd* cmd)
 			if (!entity->GetAlive() || entity->GetDormant() || entity == localplayer)
 				continue;
 
-			float dist = sqrtf(localplayer->GetVecOrigin().DistToSqr(entity->GetVecOrigin()));
+			float dist = localplayer->GetVecOrigin().DistTo(entity->GetVecOrigin());
 
 			if (dist < bestdist)
 			{

--- a/src/esp.cpp
+++ b/src/esp.cpp
@@ -611,7 +611,7 @@ void ESP::DrawPlantedBomb(C_PlantedC4* bomb)
 		C_BasePlayer* localplayer = (C_BasePlayer*)entitylist->GetClientEntity(engine->GetLocalPlayer());
 		Vector vecOrigin = bomb->GetVecOrigin();
 
-		float flDistance = sqrtf(localplayer->GetEyePosition().DistToSqr(vecOrigin));
+		float flDistance = localplayer->GetEyePosition().DistTo(vecOrigin);
 
 		float a = 450.7f;
 		float b = 75.68f;


### PR DESCRIPTION
So for 3D vectors AimTux currently does not have a vector distance function (?), only a vector distance squared function, so I have implemented a normal function to save some worthless calculations. If you just look at the code you can see that it is inefficient, as the code is finding a number squared and then square rooting it.