### PR TITLE
Implement No Smoke & Fix Ignore Scope

### DIFF
--- a/src/AimTux.cpp
+++ b/src/AimTux.cpp
@@ -49,6 +49,7 @@ int __attribute__((constructor)) aimtux_init()
 	gameEvents_vmt->ApplyVMT();
 
 	viewRender_vmt->HookVM((void*) Hooks::RenderView, 6);
+	viewRender_vmt->HookVM((void*) Hooks::RenderSmokePreViewmodel, 41);
 	viewRender_vmt->ApplyVMT();
 
 	inputInternal_vmt->HookVM((void*) Hooks::SetKeyCodeState, 92);

--- a/src/Hacks/fovchanger.cpp
+++ b/src/Hacks/fovchanger.cpp
@@ -28,6 +28,6 @@ void FOVChanger::RenderView(CViewSetup& setup, CViewSetup& hudViewSetup, unsigne
 	if (!(Settings::FOVChanger::enabled && Settings::FOVChanger::ignore_scope) || !localplayer->IsScoped())
 		setup.fov = Settings::FOVChanger::value;
 
-	if (Settings::FOVChanger::viewmodel_enabled)
+	if (!(Settings::FOVChanger::viewmodel_enabled && Settings::FOVChanger::ignore_scope) || !localplayer->IsScoped())
 		setup.fovViewmodel = Settings::FOVChanger::viewmodel_value;
 }

--- a/src/Hacks/hacks.h
+++ b/src/Hacks/hacks.h
@@ -17,6 +17,7 @@
 #include "hitmarkers.h"
 #include "namechanger.h"
 #include "noflash.h"
+#include "nosmoke.h"
 #include "nosky.h"
 #include "predictionsystem.h"
 #include "radar.h"

--- a/src/Hacks/nosmoke.cpp
+++ b/src/Hacks/nosmoke.cpp
@@ -1,0 +1,49 @@
+#include "nosmoke.h"
+
+bool Settings::NoSmoke::enabled = false;
+
+// FIXME: i'm pretty sure we don't need all of these...
+std::vector<const char*> smoke_materials = {
+		"effects/overlaysmoke",
+		"particle/beam_smoke_01",
+		"particle/particle_smokegrenade",
+		"particle/particle_smokegrenade1",
+		"particle/particle_smokegrenade2",
+		"particle/particle_smokegrenade3",
+		"particle/particle_smokegrenade_sc",
+		"particle/smoke1/smoke1",
+		"particle/smoke1/smoke1_ash",
+		"particle/smoke1/smoke1_nearcull",
+		"particle/smoke1/smoke1_nearcull2",
+		"particle/smoke1/smoke1_snow",
+		"particle/smokesprites_0001",
+		"particle/smokestack",
+		"particle/vistasmokev1/vistasmokev1",
+		"particle/vistasmokev1/vistasmokev1_emods",
+		"particle/vistasmokev1/vistasmokev1_emods_impactdust",
+		"particle/vistasmokev1/vistasmokev1_fire",
+		"particle/vistasmokev1/vistasmokev1_nearcull",
+		"particle/vistasmokev1/vistasmokev1_nearcull_fog",
+		"particle/vistasmokev1/vistasmokev1_nearcull_nodepth",
+		"particle/vistasmokev1/vistasmokev1_smokegrenade",
+		"particle/vistasmokev1/vistasmokev4_emods_nocull",
+		"particle/vistasmokev1/vistasmokev4_nearcull",
+		"particle/vistasmokev1/vistasmokev4_nocull"
+};
+
+void NoSmoke::RenderSmokePreViewmodel(bool& draw_viewmodel)
+{
+	draw_viewmodel = !Settings::NoSmoke::enabled;
+}
+
+void NoSmoke::FrameStageNotify(ClientFrameStage_t stage)
+{
+	if (stage != ClientFrameStage_t::FRAME_NET_UPDATE_POSTDATAUPDATE_END)
+		return;
+
+	for (auto material_name : smoke_materials)
+	{
+		IMaterial* mat = material->FindMaterial(material_name, TEXTURE_GROUP_OTHER);
+		mat->SetMaterialVarFlag(MATERIAL_VAR_NO_DRAW, Settings::NoSmoke::enabled);
+	}
+}

--- a/src/Hacks/nosmoke.h
+++ b/src/Hacks/nosmoke.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../SDK/SDK.h"
+#include "../interfaces.h"
+#include "../settings.h"
+
+namespace NoSmoke
+{
+	void RenderSmokePreViewmodel(bool& draw_viewmodel);
+	void FrameStageNotify(ClientFrameStage_t stage);
+};

--- a/src/Hooks/FrameStageNotify.cpp
+++ b/src/Hooks/FrameStageNotify.cpp
@@ -9,6 +9,7 @@ void Hooks::FrameStageNotify(void* thisptr, ClientFrameStage_t stage)
 	Resolver::FrameStageNotify(stage);
 	NoSky::FrameStageNotify(stage);
 	ASUSWalls::FrameStageNotify(stage);
+	NoSmoke::FrameStageNotify(stage);
 
 	client_vmt->GetOriginalMethod<FrameStageNotifyFn>(36)(thisptr, stage);
 

--- a/src/Hooks/RenderView.cpp
+++ b/src/Hooks/RenderView.cpp
@@ -10,3 +10,10 @@ void Hooks::RenderView(void* thisptr, CViewSetup& setup, CViewSetup& hudViewSetu
 
 	viewRender_vmt->GetOriginalMethod<RenderViewFn>(6)(thisptr, setup, hudViewSetup, nClearFlags, whatToDraw);
 }
+
+void Hooks::RenderSmokePreViewmodel(void* thisptr, bool draw_viewmodel)
+{
+	NoSmoke::RenderSmokePreViewmodel(draw_viewmodel);
+
+	viewRender_vmt->GetOriginalMethod<RenderSmokePreViewmodelFn>(40)(thisptr, draw_viewmodel);
+}

--- a/src/Hooks/hooks.h
+++ b/src/Hooks/hooks.h
@@ -23,6 +23,8 @@ typedef void (*PaintFn) (void*, PaintMode_t);
 typedef void (*EmitSound1Fn) (void*, IRecipientFilter&, int, int, const char*, unsigned int, const char*, float, int, float, int, int, const Vector*, const Vector*, void*, bool, float, int);
 typedef void (*EmitSound2Fn) (void*, IRecipientFilter&, int, int, const char*, unsigned int, const char*, float, int, soundlevel_t, int, int, const Vector*, const Vector*, void*, bool, float, int);
 
+typedef void (*RenderSmokePreViewmodelFn) (void*, bool);
+
 namespace Hooks
 {
 	void PaintTraverse(void* thisptr, VPANEL vgui_panel, bool force_repaint, bool allow_force);
@@ -41,6 +43,7 @@ namespace Hooks
 	void Paint(void* thisptr, PaintMode_t mode);
 	void EmitSound1(void* thisptr, IRecipientFilter& filter, int iEntIndex, int iChannel, const char* pSoundEntry, unsigned int nSoundEntryHash, const char *pSample, float flVolume, int nSeed, float flAttenuation, int iFlags, int iPitch, const Vector* pOrigin, const Vector* pDirection, void* pUtlVecOrigins, bool bUpdatePositions, float soundtime, int speakerentity);
 	void EmitSound2(void* thisptr, IRecipientFilter& filter, int iEntIndex, int iChannel, const char* pSoundEntry, unsigned int nSoundEntryHash, const char *pSample, float flVolume, int nSeed, soundlevel_t iSoundLevel, int iFlags, int iPitch, const Vector* pOrigin, const Vector* pDirection, void* pUtlVecOrigins, bool bUpdatePositions, float soundtime, int speakerentity);
+	void RenderSmokePreViewmodel(void* thisptr, bool draw_viewmodel);
 }
 
 namespace CreateMove

--- a/src/SDK/IMaterial.h
+++ b/src/SDK/IMaterial.h
@@ -138,6 +138,12 @@ enum MaterialPropertyTypes_t
 class IMaterial
 {
 public:
+	const char* GetName()
+	{
+		typedef const char* (* oGetName)(void*);
+		return getvfunc<oGetName>(this, 0)(this);
+	}
+
 	const char* GetTextureGroupName()
 	{
 		typedef const char* (* oGetTextureGroupName)(void*);

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -708,6 +708,9 @@ void VisualsTab()
 				ImGui::Checkbox("No Sky", &Settings::NoSky::enabled);
 				if (ImGui::IsItemHovered())
 					ImGui::SetTooltip("Allows for the skybox to be colored or disabled");
+				ImGui::Checkbox("No Smoke", &Settings::NoSmoke::enabled);
+				if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("Disables smoke rendering");
 			}
 			ImGui::NextColumn();
 			{

--- a/src/hooker.cpp
+++ b/src/hooker.cpp
@@ -57,6 +57,7 @@ SendClanTagFn SendClanTag;
 IsReadyCallbackFn IsReadyCallback;
 
 RecvVarProxyFn fnSequenceProxyFn;
+RecvVarProxyFn fnSmokeEffectTickBeginProxyFn;
 
 StartDrawingFn StartDrawing;
 FinishDrawingFn FinishDrawing;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -347,6 +347,8 @@ void Settings::LoadDefaultsOrSave(std::string path)
 
 	settings["AutoDefuse"]["enabled"] = Settings::AutoDefuse::enabled;
 
+	settings["NoSmoke"]["enabled"] = Settings::NoSmoke::enabled;
+
 	std::ofstream(path) << styledWriter.write(settings);
 }
 
@@ -634,6 +636,8 @@ void Settings::LoadConfig(std::string path)
 	GetButtonCode(settings["Autoblock"]["key"], &Settings::Autoblock::key);
 
 	GetBool(settings["AutoDefuse"]["enabled"], &Settings::AutoDefuse::enabled);
+
+	GetBool(settings["NoSmoke"]["enabled"], &Settings::NoSmoke::enabled);
 }
 
 void Settings::LoadSettings()

--- a/src/settings.h
+++ b/src/settings.h
@@ -635,6 +635,11 @@ namespace Settings
 		extern bool enabled;
 	}
 
+	namespace NoSmoke
+	{
+		extern bool enabled;
+	}
+
 	void LoadDefaultsOrSave(std::string path);
 	void LoadConfig(std::string path);
 	void LoadSettings();


### PR DESCRIPTION
- Disables smoke overlay and forces world rendering while in smoke via RenderSmokePreViewmodel hook
- Disables smoke rendering by setting MATERIAL_VAR_NO_DRAW on smoke's materials