### PR TITLE
Implement silent Rage AutoStrafer

### DIFF
--- a/src/Hacks/autostrafe.cpp
+++ b/src/Hacks/autostrafe.cpp
@@ -2,6 +2,7 @@
 
 bool Settings::AutoStrafe::enabled = false;
 int Settings::AutoStrafe::type = AS_FORWARDS;
+bool Settings::AutoStrafe::silent = true;
 
 void LegitStrafe(C_BasePlayer* localplayer, CUserCmd* cmd)
 {
@@ -86,7 +87,12 @@ void RageStrafe(C_BasePlayer* localplayer, CUserCmd* cmd)
 
 	Math::NormalizeAngles(angle);
 	Math::ClampAngles(angle);
-	cmd->viewangles = angle;
+
+	Vector moveold(cmd->forwardmove, cmd->sidemove, 0.0f);
+	Math::CorrectMovement(angle, cmd, moveold.x, moveold.y);
+
+	if (!Settings::AutoStrafe::silent)
+		cmd->viewangles = angle;
 }
 
 void AutoStrafe::CreateMove(CUserCmd* cmd)

--- a/src/atgui.cpp
+++ b/src/atgui.cpp
@@ -1351,6 +1351,14 @@ void MiscTab()
 					ImGui::Combo("##STRAFETYPE", &Settings::AutoStrafe::type, strafeTypes, IM_ARRAYSIZE(strafeTypes));
 				ImGui::PopItemWidth();
 			}
+
+			if (Settings::AutoStrafe::type == AS_RAGE)
+			{
+				ImGui::Checkbox("Silent", &Settings::AutoStrafe::silent);
+				if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("Strafes won't be visible for spectators");
+			}
+
 			ImGui::Columns(1);
 			ImGui::Separator();
 			ImGui::Text("Spammer");

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -283,6 +283,7 @@ void Settings::LoadDefaultsOrSave(std::string path)
 
 	settings["AutoStrafe"]["enabled"] = Settings::AutoStrafe::enabled;
 	settings["AutoStrafe"]["type"] = Settings::AutoStrafe::type;
+	settings["AutoStrafe"]["silent"] = Settings::AutoStrafe::silent;
 
 	settings["Noflash"]["enabled"] = Settings::Noflash::enabled;
 	settings["Noflash"]["value"] = Settings::Noflash::value;
@@ -635,6 +636,7 @@ void Settings::LoadConfig(std::string path)
 
 	GetVal(settings["AutoStrafe"]["enabled"], &Settings::AutoStrafe::enabled);
 	GetVal(settings["AutoStrafe"]["type"], &Settings::AutoStrafe::type);
+	GetVal(settings["AutoStrafe"]["silent"], &Settings::AutoStrafe::silent);
 
 	GetVal(settings["Noflash"]["enabled"], &Settings::Noflash::enabled);
 	GetVal(settings["Noflash"]["value"], &Settings::Noflash::value);

--- a/src/settings.h
+++ b/src/settings.h
@@ -582,6 +582,7 @@ namespace Settings
 	{
 		extern bool enabled;
 		extern int type;
+		extern bool silent;
 	}
 
 	namespace Noflash


### PR DESCRIPTION
Original author: Roskonix

- Implement 'silent' setting for Rage AutoStrafer that will make strafes invisible both client and server-side